### PR TITLE
Modifications to allow GPU training

### DIFF
--- a/base.py
+++ b/base.py
@@ -11,10 +11,11 @@ from gpytorch.constraints import Interval
 
 class BaseModule(Module, ABC):
     """Abstract base module for calibration."""
+
     def __init__(
-            self,
-            model: nn.Module,
-            **kwargs,
+        self,
+        model: nn.Module,
+        **kwargs,
     ):
         """Initializes BaseModule by registering the model to be calibrated.
 
@@ -28,14 +29,19 @@ class BaseModule(Module, ABC):
     def forward(self, x):
         pass
 
+    def to(self, device: str):
+        self.model._model.to(device)
+        super().to(device)
+
 
 class ParameterModule(BaseModule, ABC):
     """Abstract module providing the functionality to register parameters with a prior and constraint."""
+
     def __init__(
-            self,
-            model: nn.Module,
-            parameter_names: Optional[list[str]],
-            **kwargs,
+        self,
+        model: nn.Module,
+        parameter_names: Optional[list[str]],
+        **kwargs,
     ):
         """Initializes ParameterModule by initializing all named parameters.
 
@@ -110,14 +116,20 @@ class ParameterModule(BaseModule, ABC):
         raw_parameter = getattr(m, f"raw_{name}").clone()
         mask = getattr(m, f"{name}_mask")
         if mask is not None:
-            raw_parameter[~mask] = torch.zeros(torch.count_nonzero(~mask), dtype=raw_parameter.dtype)
+            raw_parameter[~mask] = torch.zeros(
+                torch.count_nonzero(~mask), dtype=raw_parameter.dtype
+            )
         if hasattr(m, f"raw_{name}_constraint"):
             constraint = getattr(m, f"raw_{name}_constraint")
-            default_offset = constraint.inverse_transform(getattr(m, f"_{name}_default"))
-            return constraint.transform(raw_parameter + default_offset)
+            default_offset = constraint.inverse_transform(
+                getattr(m, f"_{name}_default")
+            )
+            return constraint.transform(
+                raw_parameter + default_offset.to(raw_parameter)
+            )
         else:
             default_offset = getattr(m, f"_{name}_default")
-            return raw_parameter + default_offset
+            return raw_parameter + default_offset.to(raw_parameter.device)
 
     @staticmethod
     def _closure(name: str, m: Module, value: Union[float, Tensor]):
@@ -132,8 +144,12 @@ class ParameterModule(BaseModule, ABC):
             value = torch.as_tensor(value)
         if hasattr(m, f"raw_{name}_constraint"):
             constraint = getattr(m, f"raw_{name}_constraint")
-            default_offset = constraint.inverse_transform(getattr(m, f"_{name}_default"))
-            m.initialize(**{f"raw_{name}": constraint.inverse_transform(value) - default_offset})
+            default_offset = constraint.inverse_transform(
+                getattr(m, f"_{name}_default")
+            )
+            m.initialize(
+                **{f"raw_{name}": constraint.inverse_transform(value) - default_offset}
+            )
         else:
             default_offset = getattr(m, f"_{name}_default")
             m.initialize(**{f"raw_{name}": value - default_offset})
@@ -156,14 +172,14 @@ class ParameterModule(BaseModule, ABC):
         kwargs["parameter_names"] = parameter_names
 
     def _initialize_parameter(
-            self,
-            name: str,
-            size: Union[int, tuple[int]],
-            initial: Union[float, Tensor],
-            default: Union[float, Tensor],
-            prior: Optional[Prior] = None,
-            constraint: Optional[Interval] = None,
-            mask: Optional[Union[Tensor, list]] = None,
+        self,
+        name: str,
+        size: Union[int, tuple[int]],
+        initial: Union[float, Tensor],
+        default: Union[float, Tensor],
+        prior: Optional[Prior] = None,
+        constraint: Optional[Interval] = None,
+        mask: Optional[Union[Tensor, list]] = None,
     ):
         """Initializes the named parameter.
 
@@ -191,16 +207,27 @@ class ParameterModule(BaseModule, ABC):
         if mask is not None and not isinstance(mask, Tensor):
             mask = torch.as_tensor(mask)
         setattr(self, f"{name}_mask", mask)
-        self.register_parameter(f"raw_{name}", nn.Parameter(getattr(self, f"_{name}_initial")))
+        self.register_parameter(
+            f"raw_{name}", nn.Parameter(getattr(self, f"_{name}_initial"))
+        )
         if prior is not None:
-            self.register_prior(f"{name}_prior", prior, partial(self._param, name),
-                                partial(self._closure, name))
+            self.register_prior(
+                f"{name}_prior",
+                prior,
+                partial(self._param, name),
+                partial(self._closure, name),
+            )
         if constraint is not None:
             self.register_constraint(f"raw_{name}", constraint)
         self._closure(name, self, getattr(self, f"_{name}_initial").detach().clone())
         # define parameter property
-        setattr(self.__class__, name, property(fget=partial(self._param, name),
-                                               fset=partial(self._closure, name)))
+        setattr(
+            self.__class__,
+            name,
+            property(
+                fget=partial(self._param, name), fset=partial(self._closure, name)
+            ),
+        )
 
     def forward(self, x):
         raise NotImplementedError()

--- a/base.py
+++ b/base.py
@@ -30,7 +30,7 @@ class BaseModule(Module, ABC):
         pass
 
     def to(self, device: str):
-        self.model._model.to(device)
+        self.model.to(device)
         super().to(device)
 
 

--- a/base.py
+++ b/base.py
@@ -117,7 +117,9 @@ class ParameterModule(BaseModule, ABC):
         mask = getattr(m, f"{name}_mask")
         if mask is not None:
             raw_parameter[~mask] = torch.zeros(
-                torch.count_nonzero(~mask), dtype=raw_parameter.dtype
+                torch.count_nonzero(~mask),
+                dtype=raw_parameter.dtype,
+                device=raw_parameter.device,
             )
         if hasattr(m, f"raw_{name}_constraint"):
             constraint = getattr(m, f"raw_{name}_constraint")

--- a/basic_example.ipynb
+++ b/basic_example.ipynb
@@ -20,6 +20,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31e38ad0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "print(device)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "df9296aa-c352-471d-9562-0cdb1ce1f429",
    "metadata": {},
@@ -41,6 +52,7 @@
     "    nn.Linear(10, 2),\n",
     "    ).double()\n",
     "base_model.requires_grad_(False)\n",
+    "base_model.to(device)\n",
     "\n",
     "# create example data\n",
     "x = torch.rand((100, 5), dtype=torch.double)\n",
@@ -91,7 +103,8 @@
     "    y_scale_initial=torch.ones(y_size) + miscal_scale * torch.rand(y_size),\n",
     "    y_mask=y_mask,\n",
     ")\n",
-    "miscal_model.requires_grad_(False)"
+    "miscal_model.requires_grad_(False)\n",
+    "miscal_model.to(device)"
    ]
   },
   {
@@ -117,8 +130,8 @@
     "fig, ax = plt.subplots(nrows=1, ncols=y_size, figsize=(5 * y_size, 5))\n",
     "for i in range(y_size):\n",
     "    idx_sort = torch.argsort(pred[:, i])\n",
-    "    ax[i].plot(pred[idx_sort, i], \"C0x\", label=\"original\")\n",
-    "    ax[i].plot(miscal_pred[idx_sort, i], \"C1x\", label=\"miscalibrated\")\n",
+    "    ax[i].plot(pred[idx_sort, i].cpu(), \"C0x\", label=\"original\")\n",
+    "    ax[i].plot(miscal_pred[idx_sort, i].cpu(), \"C1x\", label=\"miscalibrated\")\n",
     "    ax[i].grid(color=\"gray\", linestyle=\"dashed\")\n",
     "    ax[i].set_xlabel(\"index\")\n",
     "    ax[i].set_ylabel(f\"y$_{i}$\")\n",
@@ -147,7 +160,8 @@
     "    x_size=x_size,\n",
     "    y_size=y_size,\n",
     "    y_mask=y_mask,\n",
-    ")"
+    ")\n",
+    "cal_model.to(device)"
    ]
   },
   {
@@ -206,7 +220,7 @@
     "    batch_size=pred.shape[0],\n",
     "    shuffle=True,\n",
     "    num_workers=0,\n",
-    "    pin_memory=True,\n",
+    "    pin_memory= not device =='cuda',  # we can't use this if we're on the GPU\n",
     ")\n",
     "\n",
     "# define optimizer and loss function\n",
@@ -310,8 +324,8 @@
     "fig, ax = plt.subplots(nrows=1, ncols=y_size, figsize=(5 * y_size, 5))\n",
     "for i in range(y_size):\n",
     "    idx_sort = torch.argsort(pred[:, i])\n",
-    "    ax[i].plot(pred[idx_sort, i], \"C0x\", label=\"original\")\n",
-    "    ax[i].plot(cal_pred[idx_sort, i], \"C1x\", label=\"calibrated\")\n",
+    "    ax[i].plot(pred[idx_sort, i].cpu(), \"C0x\", label=\"original\")\n",
+    "    ax[i].plot(cal_pred[idx_sort, i].cpu(), \"C1x\", label=\"calibrated\")\n",
     "    ax[i].grid(color=\"gray\", linestyle=\"dashed\")\n",
     "    ax[i].set_xlabel(\"index\")\n",
     "    ax[i].set_ylabel(f\"y$_{i}$\")\n",
@@ -340,7 +354,7 @@
     "                values = -values\n",
     "            elif \"scale\" in col[0]:\n",
     "                values = 1.0 / values\n",
-    "        df.loc[:, col] = values.detach().tolist()\n",
+    "        df.loc[:, col] = values.detach().cpu().tolist()\n",
     "pd.set_option(\"display.float_format\", \"{:.4f}\".format)"
    ]
   },
@@ -576,22 +590,14 @@
     "fig, ax = plt.subplots(nrows=1, ncols=y_size, figsize=(5 * y_size, 5))\n",
     "for i in range(y_size):\n",
     "    idx_sort = torch.argsort(pred[:, i])\n",
-    "    ax[i].plot(pred[idx_sort, i], \"C0x\", label=\"original\")\n",
-    "    ax[i].plot(transformed_pred[idx_sort, i], \"C1x\", label=\"calibrated (transformers)\")\n",
+    "    ax[i].plot(pred[idx_sort, i].cpu(), \"C0x\", label=\"original\")\n",
+    "    ax[i].plot(transformed_pred[idx_sort, i].cpu(), \"C1x\", label=\"calibrated (transformers)\")\n",
     "    ax[i].grid(color=\"gray\", linestyle=\"dashed\")\n",
     "    ax[i].set_xlabel(\"index\")\n",
     "    ax[i].set_ylabel(f\"y$_{i}$\")\n",
     "    ax[i].legend(loc=\"upper left\")\n",
     "fig.tight_layout()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "359a0a36-6385-4079-8db9-03bfb707b903",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/basic_example.ipynb
+++ b/basic_example.ipynb
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "device = 'cuda' if torch.cuda.is_available() else 'cpu'\n",
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
     "print(device)"
    ]
   },
@@ -50,12 +50,12 @@
     "    nn.Linear(5, 10),\n",
     "    nn.ReLU(),\n",
     "    nn.Linear(10, 2),\n",
-    "    ).double()\n",
+    ").double()\n",
     "base_model.requires_grad_(False)\n",
     "base_model.to(device)\n",
     "\n",
     "# create example data\n",
-    "x = torch.rand((100, 5), dtype=torch.double)\n",
+    "x = torch.rand((100, 5), dtype=torch.double, device=device)\n",
     "pred = base_model(x)"
    ]
   },
@@ -204,7 +204,13 @@
     "# define data set\n",
     "class Dataset(torch.utils.data.Dataset):\n",
     "    def __init__(self, x, y):\n",
-    "        self.x, self.y, = x, y\n",
+    "        (\n",
+    "            self.x,\n",
+    "            self.y,\n",
+    "        ) = (\n",
+    "            x,\n",
+    "            y,\n",
+    "        )\n",
     "\n",
     "    def __len__(self):\n",
     "        return self.y.shape[0]\n",
@@ -220,7 +226,7 @@
     "    batch_size=pred.shape[0],\n",
     "    shuffle=True,\n",
     "    num_workers=0,\n",
-    "    pin_memory= not device =='cuda',  # we can't use this if we're on the GPU\n",
+    "    pin_memory=not \"cuda\" in device,  # we can't use this if we're on the GPU\n",
     ")\n",
     "\n",
     "# define optimizer and loss function\n",
@@ -341,8 +347,12 @@
    "outputs": [],
    "source": [
     "# calibration parameters\n",
-    "df_x = pd.DataFrame(columns=[[\"x_offset\"] * 2 + [\"x_scale\"] * 2, [\"target\", \"learned\"] * 2])\n",
-    "df_y = pd.DataFrame(columns=[[\"y_offset\"] * 2 + [\"y_scale\"] * 2, [\"target\", \"learned\"] * 2])\n",
+    "df_x = pd.DataFrame(\n",
+    "    columns=[[\"x_offset\"] * 2 + [\"x_scale\"] * 2, [\"target\", \"learned\"] * 2]\n",
+    ")\n",
+    "df_y = pd.DataFrame(\n",
+    "    columns=[[\"y_offset\"] * 2 + [\"y_scale\"] * 2, [\"target\", \"learned\"] * 2]\n",
+    ")\n",
     "for df in [df_x, df_y]:\n",
     "    for col in df.columns:\n",
     "        model = miscal_model\n",
@@ -563,7 +573,9 @@
     "\n",
     "\n",
     "# create transformed model\n",
-    "transformed_model = TransformedModel(miscal_model, input_transformer, output_transformer)"
+    "transformed_model = TransformedModel(\n",
+    "    miscal_model, input_transformer, output_transformer\n",
+    ")"
    ]
   },
   {
@@ -591,7 +603,9 @@
     "for i in range(y_size):\n",
     "    idx_sort = torch.argsort(pred[:, i])\n",
     "    ax[i].plot(pred[idx_sort, i].cpu(), \"C0x\", label=\"original\")\n",
-    "    ax[i].plot(transformed_pred[idx_sort, i].cpu(), \"C1x\", label=\"calibrated (transformers)\")\n",
+    "    ax[i].plot(\n",
+    "        transformed_pred[idx_sort, i].cpu(), \"C1x\", label=\"calibrated (transformers)\"\n",
+    "    )\n",
     "    ax[i].grid(color=\"gray\", linestyle=\"dashed\")\n",
     "    ax[i].set_xlabel(\"index\")\n",
     "    ax[i].set_ylabel(f\"y$_{i}$\")\n",


### PR DESCRIPTION
Small modifications to prevent errors from tensors being on different devices:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

Modifications include moving default offsets and scales onto the same device as the `raw_parameter` and assigning the masked parameter tensor to the same devie as the `raw_parameter`. I've also updated the example notebook for a more general use case on either GPU or CPU devices.

My `black` autoformatter has also made some small formatting changes