### PR TITLE
allowing parameters to be initialised from a list

### DIFF
--- a/base.py
+++ b/base.py
@@ -139,7 +139,10 @@ class ParameterModule(BaseModule, ABC):
         # define initial and default value(s)
         for value, value_str in zip([initial, default], ["initial", "default"]):
             if not isinstance(value, Tensor):
-                value = float(value) * torch.ones(size)
+                if isinstance(value, list):
+                    value = torch.tensor(value)
+                else:
+                    value = float(value) * torch.ones(size)
             value_size = value.shape
             if value.dim() == 1 and isinstance(size, int):
                 value_size = value.shape[0]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -119,6 +119,26 @@ class TestParameterModule:
         assert param.shape == ndim_size
         assert raw_param.shape == ndim_size
 
+    def test_parameter_lists(self, linear_model, parameter_name, ndim_size):
+        parameter_prior = NormalPrior(loc=torch.zeros(ndim_size), scale=torch.ones(ndim_size))
+        kwargs = {
+            f"{parameter_name}_size": ndim_size,
+            f"{parameter_name}_default": torch.ones(ndim_size).tolist(),
+            f"{parameter_name}_initial": torch.ones(ndim_size).tolist(),
+            f"{parameter_name}_prior": parameter_prior,
+            f"{parameter_name}_constraint": Interval(lower_bound=-1.5, upper_bound=1.5),
+        }
+        m = ParameterModule(
+            model=linear_model,
+            parameter_names=[parameter_name],
+            **kwargs,
+        )
+        param = getattr(m, parameter_name)
+        raw_param = getattr(m, f"raw_{parameter_name}")
+
+        assert param.shape == ndim_size
+        assert raw_param.shape == ndim_size
+
     def test_parameter_mask(self, extensive_parameter_module):
         parameter_name = extensive_parameter_module.calibration_parameter_names[0]
         param = extensive_parameter_module.calibration_parameters[0]


### PR DESCRIPTION
This resolves the following error when initialising parameters from a JSON file which by default uses lists rather than tensors:

```python
File [~/notebooks/calibration-training/training/calibration_modules/decoupled_linear.py:154], in DecoupledLinearInput.__init__(self, model, x_size, x_mask, **kwargs) ...
--> [145]         value = float(value) * torch.ones(size)
    [146]     value_size = value.shape
    [147]     if value.dim() == 1 and isinstance(size, int):

TypeError: float() argument must be a string or a real number, not 'list'
```