### PR TITLE
Fix tests

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - botorch>=0.8.2
+  - botorch>=0.8.2,<=0.10.0
 
   # dev
   - ipykernel

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -141,7 +141,7 @@ class TestParameterModule:
         f = os.path.join(tmp_path, "test_module.pt")
         torch.save(extensive_parameter_module, f)
         importlib.reload(base)  # refresh ParameterModule class definition
-        m = torch.load(f)
+        m = torch.load(f, weights_only=False)
         os.remove(f)
 
         assert str(m.state_dict()) == str(extensive_parameter_module.state_dict())


### PR DESCRIPTION
Restricts botorch version and future-proofs usage of `torch.load()`.